### PR TITLE
drupiter: fix hang, functional bugs, and hub multi-select; fix QEMU test setup

### DIFF
--- a/.github/workflows/qemu-test.yml
+++ b/.github/workflows/qemu-test.yml
@@ -17,13 +17,49 @@ on:
       - 'eurorack/**'
       - 'test/qemu-arm/**'
       - 'logue-sdk/**'
+      - 'logue-sdk/docker/**'
       - 'build.sh'
       - '.github/workflows/qemu-test.yml'
   workflow_dispatch:
 
 jobs:
+  # Rebuilds and pushes the SDK container image to GHCR so the per-commit
+  # unit builds can pull the cached image instead of rebuilding it every run.
+  # Runs on main/master pushes that touch the SDK docker sources, or manually.
+  build-sdk-image:
+    name: Build & Push SDK Image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push SDK image
+        run: ./build.sh --build-image --push
+        env:
+          ENGINE: podman
+          IMAGE_REGISTRY: ghcr.io/${{ github.repository }}
+
   build-units:
     name: Build Units
+    needs: build-sdk-image
+    # Run even when build-sdk-image is skipped (PRs, non-main branches) or
+    # failed - the GHCR pull step falls back to a local build in that case.
+    if: always()
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,15 +85,23 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h
       
-      - name: Build SDK container image
-        run: ./build.sh --build-image
-        env:
-          ENGINE: podman
+      - name: Get SDK image (GHCR cache or local build)
+        id: sdk-image
+        run: |
+          if podman pull ghcr.io/${{ github.repository }}/logue-sdk-dev-env:latest 2>/dev/null; then
+            echo "Using cached SDK image from GHCR"
+            echo "image=ghcr.io/${{ github.repository }}/logue-sdk-dev-env:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "No cached SDK image found, building locally"
+            ./build.sh --build-image
+            echo "image=localhost/logue-sdk-dev-env:latest" >> "$GITHUB_OUTPUT"
+          fi
       
       - name: Build ${{ matrix.unit }}
         run: ./build.sh ${{ matrix.unit }}
         env:
           ENGINE: podman
+          IMAGE: ${{ steps.sdk-image.outputs.image }}
       
       - name: Upload unit artifact
         uses: actions/upload-artifact@v4
@@ -91,6 +135,19 @@ jobs:
         run: |
           sudo apt-get update
           sudo dpkg --add-architecture armhf
+          # Ubuntu noble does not publish armhf indexes on the standard
+          # archive (404 on archive/security.ubuntu.com), which made
+          # apt-get update fail with exit code 100. Restrict the runner's
+          # built-in sources to amd64 and add armhf via ports.ubuntu.com.
+          sudo grep -rIl '^Types: deb' /etc/apt/sources.list.d/ 2>/dev/null | while read -r f; do
+            grep -q '^Architectures:' "$f" || sudo sed -i '/^Types: deb/a Architectures: amd64' "$f"
+          done
+          echo "Types: deb" | sudo tee /etc/apt/sources.list.d/armhf-ports.sources >/dev/null
+          echo "URIs: http://ports.ubuntu.com/ubuntu-ports/" | sudo tee -a /etc/apt/sources.list.d/armhf-ports.sources >/dev/null
+          echo "Suites: noble noble-updates noble-backports" | sudo tee -a /etc/apt/sources.list.d/armhf-ports.sources >/dev/null
+          echo "Components: main universe" | sudo tee -a /etc/apt/sources.list.d/armhf-ports.sources >/dev/null
+          echo "Architectures: armhf" | sudo tee -a /etc/apt/sources.list.d/armhf-ports.sources >/dev/null
+          echo "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg" | sudo tee -a /etc/apt/sources.list.d/armhf-ports.sources >/dev/null
           sudo apt-get update
           sudo apt-get install -y \
             gcc-arm-linux-gnueabihf \
@@ -105,6 +162,12 @@ jobs:
             python3-numpy \
             python3-scipy \
             make
+          # Make the armhf runtime libraries visible to qemu's -L sysroot
+          # (/usr/arm-linux-gnueabihf) - libsndfile is not part of the
+          # cross-toolchain sysroot
+          if [ -d /usr/arm-linux-gnueabihf/lib ] && [ -d /usr/lib/arm-linux-gnueabihf ]; then
+            sudo cp -rn /usr/lib/arm-linux-gnueabihf/. /usr/arm-linux-gnueabihf/lib/ 2>/dev/null || true
+          fi
       
       - name: Build ARM unit host
         working-directory: test/qemu-arm

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@
 #   e.g.: ./build.sh clouds-revfx        # Build the unit
 #         ./build.sh clouds-revfx clean  # Clean the build
 #         ./build.sh --build-image       # Build the SDK container image
+#         ./build.sh --build-image --push  # Build + push to IMAGE_REGISTRY (GHCR)
 
 set -e
 
@@ -19,17 +20,42 @@ build_image() {
     cd "${SDK_DOCKER}"
     BUILD_ID=$(git rev-parse --short HEAD)
     VERSION=$(cat VERSION)
+
+    # Local tags (used by default)
+    local tags=(-t "logue-sdk-dev-env:${VERSION}" -t "logue-sdk-dev-env:latest")
+    # Registry tags (when IMAGE_REGISTRY is set, e.g. ghcr.io/user/repo)
+    # Tagged with the SDK build id so stale cached images can be identified.
+    if [ -n "${IMAGE_REGISTRY}" ]; then
+        tags+=(
+            -t "${IMAGE_REGISTRY}/logue-sdk-dev-env:${VERSION}-${BUILD_ID}"
+            -t "${IMAGE_REGISTRY}/logue-sdk-dev-env:latest"
+        )
+    fi
+
     $ENGINE build \
         --build-arg build="$BUILD_ID" \
         --build-arg version="$VERSION" \
-        -t "logue-sdk-dev-env:${VERSION}" \
-        -t "logue-sdk-dev-env:latest" \
+        "${tags[@]}" \
         .
     echo ">> SDK image built: logue-sdk-dev-env:${VERSION}"
+
+    # Push to the registry when requested (--push flag)
+    if [ "${PUSH_IMAGE:-0}" = "1" ]; then
+        if [ -z "${IMAGE_REGISTRY}" ]; then
+            echo ">> Error: --push requires IMAGE_REGISTRY to be set"
+            exit 1
+        fi
+        echo ">> Pushing SDK image to ${IMAGE_REGISTRY}..."
+        $ENGINE push "${IMAGE_REGISTRY}/logue-sdk-dev-env:${VERSION}-${BUILD_ID}"
+        $ENGINE push "${IMAGE_REGISTRY}/logue-sdk-dev-env:latest"
+    fi
 }
 
 # Handle --build-image flag
 if [ "$1" = "--build-image" ]; then
+    if [ "$2" = "--push" ]; then
+        PUSH_IMAGE=1
+    fi
     build_image
     exit 0
 fi

--- a/drumlogue/common/perf_mon.cc
+++ b/drumlogue/common/perf_mon.cc
@@ -18,4 +18,41 @@ uint8_t PerfMon::counter_count_ = 0;
 
 }  // namespace dsp
 
+// C-linkage export wrappers so the QEMU ARM unit host can read the counters
+// via dlsym() (the PerfMon static methods are inline and never emitted as
+// dynamic symbols once optimized/inlined).
+extern "C" {
+
+__attribute__((visibility("default")))
+uint8_t perf_mon_get_counter_count(void) {
+    return ::dsp::PerfMon::GetCounterCount();
+}
+
+__attribute__((visibility("default")))
+const char* perf_mon_get_counter_name(uint8_t id) {
+    return ::dsp::PerfMon::GetCounterName(id);
+}
+
+__attribute__((visibility("default")))
+uint32_t perf_mon_get_average_cycles(uint8_t id) {
+    return ::dsp::PerfMon::GetAverageCycles(id);
+}
+
+__attribute__((visibility("default")))
+uint32_t perf_mon_get_peak_cycles(uint8_t id) {
+    return ::dsp::PerfMon::GetPeakCycles(id);
+}
+
+__attribute__((visibility("default")))
+uint32_t perf_mon_get_min_cycles(uint8_t id) {
+    return ::dsp::PerfMon::GetMinCycles(id);
+}
+
+__attribute__((visibility("default")))
+uint32_t perf_mon_get_frame_count(uint8_t id) {
+    return ::dsp::PerfMon::GetFrameCount(id);
+}
+
+}  // extern "C"
+
 #endif  // PERF_MON

--- a/drumlogue/drupiter-synth/config.mk
+++ b/drumlogue/drupiter-synth/config.mk
@@ -86,6 +86,9 @@ UNISON_MAX_DETUNE ?= 50
 ifeq ($(PERF_MON),1)
   UDEFS = -DPERF_MON
   CXXSRC += ../common/perf_mon.cc
+  # Keep symbols so the QEMU ARM host can read PERF_MON counters via dlsym
+  # (the SDK Makefile strips unless DEBUG is set, and DEBUG adds -DDEBUG prints)
+  override STRIP := true
   # For QEMU ARM testing, also define __QEMU_ARM__ to use chrono instead of hardware registers
   ifeq ($(__QEMU_ARM__),1)
     UDEFS += -D__QEMU_ARM__

--- a/drumlogue/drupiter-synth/drupiter_synth.cc
+++ b/drumlogue/drupiter-synth/drupiter_synth.cc
@@ -285,10 +285,19 @@ void DrupiterSynth::Render(float* out, uint32_t frames) {
     // Safety: ensure output buffer and internal buffers can handle the request
     if (!out || frames == 0) return;
     
-    // CRITICAL: Limit frames to our buffer size to prevent overflow
-    if (frames > kMaxFrames) {
-        frames = kMaxFrames;
+    // BUGFIX: process arbitrarily large callbacks in bounded chunks instead of
+    // silently truncating them. The drumlogue runtime uses 64-frame buffers,
+    // but hosts may request more (e.g. the QEMU test host uses 256).
+    uint32_t processed = 0;
+    while (processed < frames) {
+        const uint32_t chunk = (frames - processed > kMaxFrames) ? kMaxFrames : (frames - processed);
+        RenderChunk(out + processed * 2, chunk);
+        processed += chunk;
     }
+}
+
+void DrupiterSynth::RenderChunk(float* out, uint32_t frames) {
+    if (!out || frames == 0 || frames > kMaxFrames) return;
     
     // Check buffer guard on entry (detect any previous overflow)
     if (buffer_guard_ != 0xDEADBEEFDEADBEEF) {
@@ -400,6 +409,12 @@ void DrupiterSynth::SetParameter(uint8_t id, int32_t value) {
             // This allows switching between MOD HUB options and remembering each value
             if (v < MOD_NUM_DESTINATIONS) {
                 mod_hub_.SetValueForDest(v, current_preset_.hub_values[v]);
+                // BUGFIX: re-base the shared knob catch on the newly selected
+                // destination's value. Otherwise the first MOD AMT turn after a
+                // switch compares the knob against the *previous* destination's
+                // value, causing random hold/catch behavior when hopping
+                // between MOD HUB options.
+                catch_mod_amt_.Init(current_preset_.hub_values[v]);
             }
             
             current_preset_.params[id] = v;
@@ -411,13 +426,15 @@ void DrupiterSynth::SetParameter(uint8_t id, int32_t value) {
             int32_t caught_v = catch_mod_amt_.Update(v);
             const int32_t actual_value = mod_hub_.SetValueAndGetClamped(caught_v);
             
-            // Store the ORIGINAL UI value (0-100), not the clamped value
-            // This is critical for proper restoration when switching destinations
+            // Store the EFFECTIVE 0-100 value (post knob-catch), not the raw
+            // knob position. While the knob is catching, the raw value has not
+            // been applied; storing it would make the destination jump when
+            // restored after switching MOD HUB options.
             {
                 uint8_t dest = current_preset_.params[PARAM_MOD_HUB];
                 if (dest < MOD_NUM_DESTINATIONS) {
-                    // Store original 0-100 value for restoration later
-                    current_preset_.hub_values[dest] = v;  // Store original, not clamped
+                    // Store effective 0-100 value for restoration later
+                    current_preset_.hub_values[dest] = caught_v;
                     
                     // Apply specific destinations to DSP components immediately
                     switch (dest) {
@@ -879,16 +896,27 @@ void DrupiterSynth::LoadPreset(uint8_t preset_id) {
     xmod_depth_ = current_preset_.params[PARAM_XMOD] / 100.0f;
     sync_mode_ = current_preset_.params[PARAM_SYNC];
     
-    // Restore MOD HUB values from preset (source of truth for hub state)
-    // Must be done BEFORE applying parameters
+    // Apply all parameters to DSP components
+    for (uint8_t i = 0; i < PARAM_COUNT; ++i) {
+        SetParameter(i, current_preset_.params[i]);
+    }
+    
+    // BUGFIX: restore MOD HUB values AFTER the parameter loop. Factory presets
+    // keep PARAM_MOD_AMT at 0 ("amount in hub_values"), so SetParameter(MOD_AMT)
+    // above overwrites the selected destination's value with 0 and destroys
+    // the preset's real modulation/synth-mode setting (e.g. Init preset loaded
+    // VCF TYPE 0 instead of its stored 1). Hub state must win over the dummy
+    // MOD_AMT param value.
     mod_hub_.SetDestination(current_preset_.params[PARAM_MOD_HUB]);
     for (uint8_t dest = 0; dest < MOD_NUM_DESTINATIONS; ++dest) {
         mod_hub_.SetValueForDest(dest, current_preset_.hub_values[dest]);
     }
-    
-    // Apply all parameters to DSP components
-    for (uint8_t i = 0; i < PARAM_COUNT; ++i) {
-        SetParameter(i, current_preset_.params[i]);
+    // Re-base the knob catch on the restored destination value
+    {
+        uint8_t dest = current_preset_.params[PARAM_MOD_HUB];
+        if (dest < MOD_NUM_DESTINATIONS) {
+            catch_mod_amt_.Init(current_preset_.hub_values[dest]);
+        }
     }
     
     // Initialize effect and LFO settings from preset (critical for preset load)
@@ -1042,9 +1070,12 @@ DrupiterSynth::RenderSetup DrupiterSynth::PrepareRenderSetup(uint32_t frames) {
     setup.vca_kybd = mod_hub_.GetValueNormalizedUnipolar(MOD_VCA_KYBD);
     
     // Update synthesis mode and allocator settings
+    // BUGFIX: guard against switching mode while notes are playing, matching
+    // the SetParameter path - otherwise an S MODE change flips the mode
+    // mid-note and glitches voices/envelopes.
     const uint8_t synth_mode_value = mod_hub_.GetValue(MOD_SYNTH_MODE);
     const dsp::SynthMode synth_mode = static_cast<dsp::SynthMode>(synth_mode_value < 3 ? synth_mode_value : 0);
-    if (synth_mode != current_mode_) {
+    if (synth_mode != current_mode_ && !allocator_.IsAnyVoiceActive()) {
         current_mode_ = synth_mode;
         allocator_.SetMode(current_mode_);
     }

--- a/drumlogue/drupiter-synth/drupiter_synth.h
+++ b/drumlogue/drupiter-synth/drupiter_synth.h
@@ -384,6 +384,12 @@ public:
      */
     dsp::JupiterDCO& GetDCO2() { return dco2_; }
 
+    /**
+     * @brief Get current sync mode (for renderers)
+     * @return 0=OFF, 1=SOFT, 2=HARD
+     */
+    uint8_t GetSyncMode() const { return sync_mode_; }
+
 private:
     // Voice allocator (Hoover v2.0)
     dsp::VoiceAllocator allocator_;
@@ -595,6 +601,13 @@ private:
      * @return Render setup struct
      */
     RenderSetup PrepareRenderSetup(uint32_t frames);
+    
+    /**
+     * @brief Render a single chunk of up to kMaxFrames frames
+     * @param out Output buffer (stereo interleaved)
+     * @param frames Number of frames (must be <= kMaxFrames)
+     */
+    void RenderChunk(float* out, uint32_t frames);
     
     /**
      * @brief Process per-frame modulation

--- a/drumlogue/drupiter-synth/dsp/jupiter_vcf.cc
+++ b/drumlogue/drupiter-synth/dsp/jupiter_vcf.cc
@@ -198,16 +198,16 @@ void JupiterVCF::SetCutoff(float freq_hz) {
 
 void JupiterVCF::SetCutoffModulated(float freq_hz) {
     const float new_cutoff = ClampCutoff(freq_hz);
-    // Track the latest requested cutoff for change detection.
-    // Only recompute coefficients when the cutoff moved materially
-    // (1 Hz quantized), so continuous modulation sweeps do not trigger
-    // a full coefficient recalculation on every sample.
-    if (fabsf(new_cutoff - prev_cutoff_hz_) > kCutoffUpdateThresholdHz) {
+    // Compare against the last *applied* cutoff (not the last requested one)
+    // so that small per-sample deltas accumulate: a slow modulation sweep
+    // (e.g. long envelope release) still triggers a coefficient recompute
+    // once the cumulative change exceeds the threshold. The applied cutoff
+    // is quantized to 1 Hz steps, which is inaudible but bounds the
+    // recompute rate during continuous modulation.
+    if (fabsf(new_cutoff - cutoff_hz_) > kCutoffUpdateThresholdHz) {
         cutoff_hz_ = new_cutoff;
         prev_cutoff_hz_ = new_cutoff;
         coefficients_dirty_ = true;
-    } else {
-        prev_cutoff_hz_ = new_cutoff;
     }
 }
 

--- a/drumlogue/drupiter-synth/dsp/jupiter_vcf.cc
+++ b/drumlogue/drupiter-synth/dsp/jupiter_vcf.cc
@@ -197,12 +197,17 @@ void JupiterVCF::SetCutoff(float freq_hz) {
 }
 
 void JupiterVCF::SetCutoffModulated(float freq_hz) {
-    float new_cutoff = ClampCutoff(freq_hz);
-    // Phase 6: Parameter change detection - only mark dirty if cutoff actually changed
-    if (fabsf(new_cutoff - prev_cutoff_hz_) > 1e-6f) {
+    const float new_cutoff = ClampCutoff(freq_hz);
+    // Track the latest requested cutoff for change detection.
+    // Only recompute coefficients when the cutoff moved materially
+    // (1 Hz quantized), so continuous modulation sweeps do not trigger
+    // a full coefficient recalculation on every sample.
+    if (fabsf(new_cutoff - prev_cutoff_hz_) > kCutoffUpdateThresholdHz) {
         cutoff_hz_ = new_cutoff;
         prev_cutoff_hz_ = new_cutoff;
         coefficients_dirty_ = true;
+    } else {
+        prev_cutoff_hz_ = new_cutoff;
     }
 }
 

--- a/drumlogue/drupiter-synth/dsp/jupiter_vcf.h
+++ b/drumlogue/drupiter-synth/dsp/jupiter_vcf.h
@@ -31,6 +31,12 @@ public:
     // Lookup table sizes
     static constexpr int kTanhTableSize = 512;        // Tanh[-4,4] with 512 entries
     static constexpr int kKbdTrackingTableSize = 128;  // One entry per MIDI note
+
+    // Coefficient recompute threshold (Hz). Modulation sweeps move the cutoff
+    // continuously; recomputing the filter coefficients at the full sample
+    // rate is the dominant polyphonic CPU cost. Quantizing updates to 1 Hz
+    // steps is inaudible and matches the mono path gating in drupiter_synth.cc.
+    static constexpr float kCutoffUpdateThresholdHz = 1.0f;
     
     /**
      * @brief Filter modes

--- a/drumlogue/drupiter-synth/dsp/unison_oscillator.cc
+++ b/drumlogue/drupiter-synth/dsp/unison_oscillator.cc
@@ -34,7 +34,10 @@ UnisonOscillator::UnisonOscillator()
     , detune_cents_(10.0f)
     , stereo_spread_(0.7f)
     , scale_(1.0f / sqrtf(7.0f))
-    , waveform_(JupiterDCO::WAVEFORM_SAW)
+    // BUGFIX: must match the waveform Init() applies to the internal
+    // oscillators (WAVEFORM_SAW_PWM), otherwise the first SetWaveform(SAW)
+    // would early-return and never propagate.
+    , waveform_(JupiterDCO::WAVEFORM_SAW_PWM)
     , pulse_width_(0.5f) {
     memset(voice_detunes_, 0, sizeof(voice_detunes_));
     memset(voice_pans_, 0, sizeof(voice_pans_));

--- a/drumlogue/drupiter-synth/dsp/unison_oscillator.cc
+++ b/drumlogue/drupiter-synth/dsp/unison_oscillator.cc
@@ -32,7 +32,10 @@ UnisonOscillator::UnisonOscillator()
     , sample_rate_(48000.0f)
     , base_freq_(440.0f)
     , detune_cents_(10.0f)
-    , stereo_spread_(0.7f) {
+    , stereo_spread_(0.7f)
+    , scale_(1.0f / sqrtf(7.0f))
+    , waveform_(JupiterDCO::WAVEFORM_SAW)
+    , pulse_width_(0.5f) {
     memset(voice_detunes_, 0, sizeof(voice_detunes_));
     memset(voice_pans_, 0, sizeof(voice_pans_));
 }
@@ -48,6 +51,7 @@ void UnisonOscillator::Init(float sample_rate, uint8_t num_voices) {
     if (num_voices > kMaxVoices) num_voices = kMaxVoices;
     if ((num_voices & 1) == 0) num_voices++;  // Make odd
     num_voices_ = num_voices;
+    UpdateScale();
     
     // Initialize all oscillators
     for (uint8_t i = 0; i < kMaxVoices; i++) {
@@ -75,12 +79,19 @@ void UnisonOscillator::SetFrequency(float freq_hz) {
 }
 
 void UnisonOscillator::SetWaveform(JupiterDCO::Waveform waveform) {
+    // OPTIMIZATION: skip re-propagation when the waveform is unchanged
+    // (called once per audio frame from UnisonRenderer)
+    if (waveform == waveform_) return;
+    waveform_ = waveform;
     for (uint8_t i = 0; i < num_voices_; i++) {
         oscillators_[i].SetWaveform(waveform);
     }
 }
 
 void UnisonOscillator::SetPulseWidth(float pw) {
+    // OPTIMIZATION: skip re-propagation when the value is unchanged
+    if (fabsf(pw - pulse_width_) < 1e-4f) return;
+    pulse_width_ = pw;
     for (uint8_t i = 0; i < num_voices_; i++) {
         oscillators_[i].SetPulseWidth(pw);
     }
@@ -138,8 +149,7 @@ void UnisonOscillator::CalculateDetuneRatios() {
     }
 }
 
-void UnisonOscillator::CalculatePanPositions() {
-    // Pan voices using golden angle spiral (like sunflower seeds)
+void UnisonOscillator::CalculatePanPositions() {    // Pan voices using golden angle spiral (like sunflower seeds)
     // This creates natural stereo spread without periodic patterns
     //
     // Golden angle ≈ 137.5° creates optimal non-repeating distribution
@@ -153,6 +163,11 @@ void UnisonOscillator::CalculatePanPositions() {
     
     // Center voice always stays centered
     voice_pans_[0] = 0.0f;
+}
+
+void UnisonOscillator::UpdateScale() {
+    // Precompute the mixing scale so Process() avoids sqrtf() per sample
+    scale_ = 1.0f / sqrtf(static_cast<float>(num_voices_));
 }
 
 }  // namespace dsp

--- a/drumlogue/drupiter-synth/dsp/unison_oscillator.h
+++ b/drumlogue/drupiter-synth/dsp/unison_oscillator.h
@@ -171,9 +171,9 @@ public:
 #endif
         
         // Scale by voice count to prevent clipping (same for both paths)
-        float scale = 1.0f / sqrtf(static_cast<float>(num_voices_));
-        *left *= scale;
-        *right *= scale;
+        // OPTIMIZATION: precomputed when the voice count changes
+        *left *= scale_;
+        *right *= scale_;
     }
     
     /**
@@ -196,6 +196,9 @@ private:
     float base_freq_;                     // Center frequency
     float detune_cents_;                  // Detune amount in cents
     float stereo_spread_;                 // Stereo width (0-1)
+    float scale_;                         // 1/sqrt(num_voices_) mixing scale (cached)
+    JupiterDCO::Waveform waveform_;       // Current waveform (change detection)
+    float pulse_width_;                   // Current pulse width (change detection)
     
     /**
      * @brief Calculate detune ratios using golden ratio spread
@@ -206,6 +209,11 @@ private:
      * @brief Calculate pan positions using golden ratio spiral
      */
     void CalculatePanPositions();
+    
+    /**
+     * @brief Recompute the cached mixing scale from the voice count
+     */
+    void UpdateScale();
     
     /**
      * @brief Convert cents to frequency ratio

--- a/drumlogue/drupiter-synth/dsp/voice_allocator.h
+++ b/drumlogue/drupiter-synth/dsp/voice_allocator.h
@@ -111,7 +111,16 @@ public:
 		}
 	}
 
-	bool IsAnyVoiceActive() const { return active_voices_ > 0; }
+    // Scans voices (active_voices_ counter is not maintained); only called on
+    // parameter changes, never in the audio render loop.
+    bool IsAnyVoiceActive() const {
+        for (uint8_t i = 0; i < max_voices_; ++i) {
+            if (voices_[i].active || voices_[i].env_amp.IsActive()) {
+                return true;
+            }
+        }
+        return false;
+    }
 	const Voice& GetVoice(uint8_t idx) const { return voices_[idx]; }
 	Voice& GetVoiceMutable(uint8_t idx) { return voices_[idx]; }
 	SynthMode GetMode() const { return mode_; }

--- a/drumlogue/drupiter-synth/mono_renderer.cc
+++ b/drumlogue/drupiter-synth/mono_renderer.cc
@@ -57,12 +57,23 @@ float MonoRenderer::RenderMono(
     synth.GetDCO2().SetFrequency(freq2);
 
     // Only process DCO2 if it's audible (level > 0) or needed for XMOD
-    const bool dco2_needed = (dco2_level > kMinModulation) || (xmod_depth > kMinModulation);
+    // BUGFIX: also run DCO2 as the sync master when SYNC is enabled, even if
+    // its level is zero - otherwise the SYNC parameter had no audible effect
+    const bool sync_enabled = synth.GetSyncMode() != 0;
+    const bool dco2_needed = (dco2_level > kMinModulation) || (xmod_depth > kMinModulation) || sync_enabled;
 
     float dco2_out = 0.0f;
     if (dco2_needed) {
         // Process DCO2 first to get fresh output for FM
         dco2_out = synth.GetDCO2().Process();
+
+        // Hard sync (DCO1 slave to DCO2 master): reset DCO1 phase when DCO2 wraps
+        // Note: Sync disabled when XMOD is active (Jupiter-8 processing order)
+        if (sync_enabled && xmod_depth <= kMinModulation) {
+            if (synth.GetDCO2().DidWrap()) {
+                synth.GetDCO1().ResetPhase();
+            }
+        }
 
         // Cross-modulation (DCO2 . DCO1 FM) - Jupiter-8 style
         // Only apply FM if XMOD depth is significant

--- a/drumlogue/drupiter-synth/polyphonic_renderer.cc
+++ b/drumlogue/drupiter-synth/polyphonic_renderer.cc
@@ -36,6 +36,8 @@ static uint8_t cached_dco1_wave = 255;  // Cache to avoid redundant SetWaveform 
 static uint8_t cached_dco2_wave = 255;
 static float cached_inv_voice_count = 1.0f;  // Pre-calculated reciprocal of voice count
 static uint8_t cached_active_voice_count = 0;
+static float cached_resonance = -1.0f;      // Cache to avoid redundant SetResonance calls
+static int cached_vcf_mode = -1;            // Cache to avoid redundant SetMode calls
 
 // Map DCO1 UI parameter value (0-4) to waveform enum
 // DCO1 waveforms: SAW(0), SQR(1), PUL(2), TRI(3), SAW_PWM(4)
@@ -238,9 +240,18 @@ float PolyphonicRenderer::RenderVoices(
         const float voice_cutoff_modulated = voice_cutoff_base * fast_pow2(voice_total_mod);
 
         // Set per-voice filter parameters and process
+        // OPTIMIZATION: SetResonance/SetMode only mark dirty on change, but
+        // avoid the per-voice-per-sample call overhead entirely by caching
+        // (resonance and mode only change when parameters change).
+        if (resonance != cached_resonance) {
+            cached_resonance = resonance;
+            voice_mut.vcf.SetResonance(resonance);
+        }
+        if (static_cast<int>(vcf_mode) != cached_vcf_mode) {
+            cached_vcf_mode = static_cast<int>(vcf_mode);
+            voice_mut.vcf.SetMode(vcf_mode);
+        }
         voice_mut.vcf.SetCutoffModulated(voice_cutoff_modulated);
-        voice_mut.vcf.SetResonance(resonance);
-        voice_mut.vcf.SetMode(vcf_mode);
 
         float voice_filtered = voice_hpf_out;
         if (vcf_cutoff_param < 100) {
@@ -251,8 +262,10 @@ float PolyphonicRenderer::RenderVoices(
         float voice_output = voice_filtered * voice_env;
 
         // Apply velocity scaling to VCA amplitude (soft hits quieter, loud hits louder)
-        // Map velocity 0-127 to VCA multiplier 0.2-1.0 (soft hits still audible)
-        const float voice_vca_gain = 0.2f + (voice.velocity / 127.0f) * 0.8f;  // 0.2 to 1.0
+        // BUGFIX: voice.velocity is already normalized 0.0-1.0 (VelocityToFloat);
+        // dividing by 127 again clamped the gain to ~0.2 with no audible range.
+        // Map normalized velocity to VCA multiplier 0.2-1.0 (soft hits still audible)
+        const float voice_vca_gain = 0.2f + voice.velocity * 0.8f;  // 0.2 to 1.0
         voice_output *= voice_vca_gain;
 
         // Add filtered, velocity-scaled voice to mix

--- a/drumlogue/drupiter-synth/polyphonic_renderer.cc
+++ b/drumlogue/drupiter-synth/polyphonic_renderer.cc
@@ -102,6 +102,21 @@ float PolyphonicRenderer::RenderVoices(
     // OPTIMIZATION: Check HPF condition once before voice loop instead of per-voice
     const bool apply_hpf = hpf_alpha > 0.0f;
 
+    // OPTIMIZATION: resonance and mode only change when parameters change.
+    // Update ALL voices in a single pre-loop pass when they do, instead of
+    // calling the setters per voice per sample. (The cache must not be
+    // updated inside the voice loop, or only the first active voice would
+    // receive the new setting.)
+    if (resonance != cached_resonance || static_cast<int>(vcf_mode) != cached_vcf_mode) {
+        cached_resonance = resonance;
+        cached_vcf_mode = static_cast<int>(vcf_mode);
+        for (uint8_t v = 0; v < DRUPITER_MAX_VOICES; v++) {
+            dsp::Voice& voice_mut = synth.GetAllocator().GetVoiceMutable(v);
+            voice_mut.vcf.SetResonance(resonance);
+            voice_mut.vcf.SetMode(vcf_mode);
+        }
+    }
+
     // Render each active voice
     for (uint8_t v = 0; v < DRUPITER_MAX_VOICES; v++) {
         const dsp::Voice& voice = synth.GetAllocator().GetVoice(v);
@@ -239,18 +254,7 @@ float PolyphonicRenderer::RenderVoices(
         // Apply modulation to cutoff base
         const float voice_cutoff_modulated = voice_cutoff_base * fast_pow2(voice_total_mod);
 
-        // Set per-voice filter parameters and process
-        // OPTIMIZATION: SetResonance/SetMode only mark dirty on change, but
-        // avoid the per-voice-per-sample call overhead entirely by caching
-        // (resonance and mode only change when parameters change).
-        if (resonance != cached_resonance) {
-            cached_resonance = resonance;
-            voice_mut.vcf.SetResonance(resonance);
-        }
-        if (static_cast<int>(vcf_mode) != cached_vcf_mode) {
-            cached_vcf_mode = static_cast<int>(vcf_mode);
-            voice_mut.vcf.SetMode(vcf_mode);
-        }
+        // Set per-voice filter cutoff and process
         voice_mut.vcf.SetCutoffModulated(voice_cutoff_modulated);
 
         float voice_filtered = voice_hpf_out;

--- a/drumlogue/drupiter-synth/unison_renderer.cc
+++ b/drumlogue/drupiter-synth/unison_renderer.cc
@@ -84,7 +84,12 @@ float UnisonRenderer::RenderUnison(
     freq2 *= pitch_mod_ratio;
     
     // Apply pitch bend to DCO2 (matches unison_freq behavior)
-    freq2 *= smoothed_pitch_bend;
+    // BUGFIX: was multiplying by the raw semitone value, which zeroed the
+    // frequency at center bend and produced wrong ratios otherwise
+    if (smoothed_pitch_bend != 0.0f) {
+        const float pitch_bend_ratio = semitones_to_ratio(smoothed_pitch_bend);
+        freq2 *= pitch_bend_ratio;
+    }
 
     synth.GetDCO2().SetFrequency(freq2);
     float dco2_out = synth.GetDCO2().Process();

--- a/test/drupiter-synth/main.cc
+++ b/test/drupiter-synth/main.cc
@@ -2468,6 +2468,86 @@ static bool TestCatchableValueFloat() {
 }
 
 // ============================================================================
+// Hub Multi-Select: destination switching, value restore, catch re-basing
+// ============================================================================
+
+static bool TestHubMultiSelect() {
+    std::cout << "\n--- Hub Multi-Select (destination switching) Test ---" << std::endl;
+    
+    DrupiterSynth synth;
+    unit_runtime_desc_t desc = {};
+    desc.api = UNIT_API_INIT(0, 1);
+    desc.samplerate = 48000;
+    desc.frames_per_buffer = 64;
+    desc.input_channels = 0;
+    desc.output_channels = 2;
+    if (synth.Init(&desc) != k_unit_err_none) {
+        std::cout << "    ERROR: Synth init failed" << std::endl;
+        return false;
+    }
+    
+    // 1. Select S MODE (dest 14) and set POLY (UI 50 -> clamped 1)
+    synth.SetParameter(DrupiterSynth::PARAM_MOD_HUB, MOD_SYNTH_MODE);
+    synth.SetParameter(DrupiterSynth::PARAM_MOD_AMT, 50);
+    if (synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT) != 50 ||
+        synth.GetAllocator().GetMode() != dsp::SYNTH_MODE_POLYPHONIC) {
+        std::cout << "    ERROR: S MODE=50 should be POLY (value="
+                  << synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT)
+                  << ", mode=" << (int)synth.GetAllocator().GetMode() << ")" << std::endl;
+        return false;
+    }
+    
+    // 2. Switch to UNI DET (dest 15) and set 30
+    synth.SetParameter(DrupiterSynth::PARAM_MOD_HUB, MOD_UNISON_DETUNE);
+    synth.SetParameter(DrupiterSynth::PARAM_MOD_AMT, 30);
+    if (synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT) != 30) {
+        std::cout << "    ERROR: UNI DET value not stored (got "
+                  << synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT) << ")" << std::endl;
+        return false;
+    }
+    
+    // 3. Switch back to S MODE: the per-destination value must restore to 50
+    //    and the mode must remain POLY
+    synth.SetParameter(DrupiterSynth::PARAM_MOD_HUB, MOD_SYNTH_MODE);
+    if (synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT) != 50) {
+        std::cout << "    ERROR: S MODE value not restored on switch-back (got "
+                  << synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT) << ")" << std::endl;
+        return false;
+    }
+    if (synth.GetAllocator().GetMode() != dsp::SYNTH_MODE_POLYPHONIC) {
+        std::cout << "    ERROR: mode changed while switching destinations" << std::endl;
+        return false;
+    }
+    
+    // 4. Catch re-basing: an immediate MOD AMT turn after a switch must apply
+    //    (no stale knob-catch state from the previous destination)
+    synth.SetParameter(DrupiterSynth::PARAM_MOD_AMT, 100);
+    if (synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT) != 100 ||
+        synth.GetAllocator().GetMode() != dsp::SYNTH_MODE_UNISON) {
+        std::cout << "    ERROR: post-switch turn not applied (value="
+                  << synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT) << ")" << std::endl;
+        return false;
+    }
+    
+    // 5. Preset load must preserve the selected destination's hub value
+    //    (previously SetParameter(MOD_AMT, 0) clobbered it to 0)
+    synth.LoadPreset(0);  // Init preset: MOD_HUB=MOD_VCF_TYPE, hub[VCF_TYPE]=1 (LP24)
+    {
+        uint8_t dest = synth.GetCurrentPreset().params[DrupiterSynth::PARAM_MOD_HUB];
+        int32_t expected = synth.GetCurrentPreset().hub_values[dest];
+        if (synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT) != expected) {
+            std::cout << "    ERROR: preset load clobbered hub value for dest "
+                      << (int)dest << " (expected " << expected << ", got "
+                      << synth.GetParameter(DrupiterSynth::PARAM_MOD_AMT) << ")" << std::endl;
+            return false;
+        }
+    }
+    
+    std::cout << "    PASSED: Hub multi-select value restore, catch re-basing, preset load" << std::endl;
+    return true;
+}
+
+// ============================================================================
 // JP-8 Phase 6: Performance & Stability Tests
 // ============================================================================
 
@@ -2932,6 +3012,9 @@ int main(int argc, char** argv) {
         ok = false;
     }
     if (!TestCatchableValueFloat()) {
+        ok = false;
+    }
+    if (!TestHubMultiSelect()) {
         ok = false;
     }
     

--- a/test/drupiter-synth/main.cc
+++ b/test/drupiter-synth/main.cc
@@ -2589,8 +2589,54 @@ static bool TestVCFCoefficientCaching() {
     return true;
 }
 
-static bool TestDenormalHandling() {
-    // Verify that denormal flushing prevents ARM FPU performance spikes
+static bool TestSlowCutoffSweepAccumulates() {
+    // Regression test: SetCutoffModulated must accumulate small per-sample
+    // cutoff changes against the last APPLIED cutoff, otherwise slow
+    // modulation sweeps never cross the 1 Hz recompute threshold and the
+    // filter cutoff freezes.
+    std::cout << "\n--- Slow Cutoff Sweep Accumulation Test ---" << std::endl;
+    
+    dsp::JupiterVCF vcf;
+    vcf.Init(48000.0f);
+    vcf.SetResonance(0.0f);
+    vcf.SetMode(dsp::JupiterVCF::MODE_LP24);
+    
+    // 2 kHz test tone
+    float phase = 0.0f;
+    const float freq = 2000.0f;
+    
+    float early_energy = 0.0f;
+    float late_energy = 0.0f;
+    float cutoff = 100.0f;
+    
+    for (int i = 0; i < 20000; i++) {
+        phase += 2.0f * M_PI * freq / 48000.0f;
+        if (phase >= 2.0f * M_PI) phase -= 2.0f * M_PI;
+        const float input = 0.5f * sinf(phase);
+        
+        // Slow sweep: +0.5 Hz per sample. With per-request change detection
+        // the delta never exceeds 1 Hz and the filter would freeze at ~100 Hz;
+        // with accumulation the cutoff follows up to ~10 kHz.
+        cutoff += 0.5f;
+        vcf.SetCutoffModulated(cutoff);
+        
+        const float out = vcf.Process(input);
+        if (i < 2000) early_energy += fabsf(out);
+        if (i >= 18000) late_energy += fabsf(out);
+    }
+    
+    // Cutoff swept 100 Hz -> ~10 kHz; the 2 kHz tone must pass at the end
+    if (late_energy < 5.0f * early_energy) {
+        std::cout << "    ERROR: filter cutoff did not follow slow sweep "
+                  << "(early=" << early_energy << ", late=" << late_energy << ")" << std::endl;
+        return false;
+    }
+    
+    std::cout << "    PASSED: slow cutoff sweep accumulates and recomputes coefficients" << std::endl;
+    return true;
+}
+
+static bool TestDenormalHandling() {    // Verify that denormal flushing prevents ARM FPU performance spikes
     // by processing signals with very small amplitudes (denormal region)
     std::cout << "\n--- Denormal Handling Test ---" << std::endl;
     
@@ -2973,6 +3019,9 @@ int main(int argc, char** argv) {
 
     ok = true;
     if (!TestVCFCoefficientCaching()) {
+        ok = false;
+    }
+    if (!TestSlowCutoffSweepAccumulates()) {
         ok = false;
     }
     if (!TestDenormalHandling()) {

--- a/test/drupiter-synth/perf_test.cc
+++ b/test/drupiter-synth/perf_test.cc
@@ -107,9 +107,11 @@ private:
         std::cout << "Synth initialized successfully\n";
 
         // Set synthesis mode via hub control (not default voice allocator)
-        // MOD_SYNTH_MODE = 14, values: 0=MONO, 1=POLY, 2=UNISON
+        // MOD_SYNTH_MODE = 14. The hub maps UI values 0-100 onto the
+        // destination range (0-2), so mode = value * 50: 0=MONO, 50=POLY,
+        // 100=UNISON.
         const uint8_t synth_mode = (voice_count == 1) ? 0 : 1;  // MONO for 1 voice, POLY for 2+ voices
-        synth_.SetHubValue(14, synth_mode);  // MOD_SYNTH_MODE
+        synth_.SetHubValue(14, synth_mode * 50);  // MOD_SYNTH_MODE
 
         // Reset performance counters
         PERF_MON_RESET();

--- a/test/qemu-arm/Makefile
+++ b/test/qemu-arm/Makefile
@@ -13,7 +13,7 @@ else
 endif
 
 # Define the targets to delegate
-.PHONY: all help install-podman check-podman podman-build podman-test test-unit podman-shell generate-signals performance-test clean status setup which-makefile
+.PHONY: all help install-podman check-podman podman-build podman-test test-unit perf-test podman-shell generate-signals performance-test clean status setup which-makefile
 
 # Delegate all targets to the appropriate Makefile
 all:
@@ -23,7 +23,7 @@ all:
 	$(MAKE) -f $(MAKEFILE_TO_USE) all
 
 # Delegate common targets
-help install-podman check-podman podman-build podman-test test-unit podman-shell generate-signals performance-test clean status:
+help install-podman check-podman podman-build podman-test test-unit perf-test podman-shell generate-signals performance-test clean status:
 	$(MAKE) -f $(MAKEFILE_TO_USE) $@
 
 # Quick setup for new users (macOS)

--- a/test/qemu-arm/Makefile.podman
+++ b/test/qemu-arm/Makefile.podman
@@ -1,12 +1,21 @@
 # Makefile for QEMU ARM unit host using Podman on macOS
 # Provides ARM cross-compilation via Linux container
+#
+# Usage:
+#   make test-unit UNIT=drupiter-synth          # Run unit in QEMU ARM
+#   make perf-test UNIT=drupiter-synth          # Rebuild with PERF_MON + profile
+#   make podman-test                            # Test all built units
+#   make generate-signals                       # Generate test WAVs (in container)
 
-.PHONY: all clean podman-build podman-test podman-shell check-podman install-podman help
+.PHONY: all clean podman-build podman-test podman-shell check-podman install-podman help generate-signals test-unit perf-test performance-test status
 
 # Container settings
 CONTAINER_IMAGE := ubuntu:22.04
 CONTAINER_NAME := drumlogue-arm-builder
 WORKSPACE_DIR := /workspace
+
+# ARM unit host sources (used for stale-check rebuilds)
+ARM_SOURCES := unit_host.c wav_file.c sdk_stubs.c unit_host.h wav_file.h sdk_stubs.h Makefile.arm
 
 # Check if running on macOS
 UNAME_S := $(shell uname -s)
@@ -26,13 +35,14 @@ help:
 	@echo "  make check-podman      # Verify Podman installation"
 	@echo ""
 	@echo "Build & Test:"
-	@echo "  make podman-build      # Build ARM unit host in container"
-	@echo "  make podman-test       # Run QEMU ARM tests in container"
+	@echo "  make podman-build      # Build ARM unit host in container (if stale)"
+	@echo "  make test-unit UNIT=drupiter-synth   # Test specific unit in QEMU ARM"
+	@echo "  make perf-test UNIT=drupiter-synth   # PERF_MON build + CPU profile in QEMU ARM"
+	@echo "  make podman-test       # Run QEMU ARM tests for all built units"
 	@echo "  make podman-shell      # Enter container for debugging"
 	@echo ""
 	@echo "Development:"
-	@echo "  make generate-signals  # Create test WAV files"
-	@echo "  make test-unit UNIT=clouds-revfx  # Test specific unit"
+	@echo "  make generate-signals  # Create test WAV files (in container)"
 	@echo ""
 	@echo "Cleanup:"
 	@echo "  make clean             # Remove built artifacts"
@@ -61,133 +71,72 @@ check-podman:
 	@echo "Available space:"
 	@podman system df
 
-# Build ARM unit host using Podman
-podman-build: check-podman
+# Build ARM unit host using Podman (only when stale)
+unit_host_arm: $(ARM_SOURCES)
 	@echo "Building ARM unit host in Podman container..."
-	podman run --rm -it \
+	podman run --rm --entrypoint bash \
 		-v "$(PWD):$(WORKSPACE_DIR):Z" \
 		-w $(WORKSPACE_DIR) \
 		$(CONTAINER_IMAGE) \
-		bash -c '\
-		apt-get update -qq && \
-		dpkg --add-architecture armhf && \
-		apt-get update -qq && \
-		apt-get install -y -qq \
-			gcc-arm-linux-gnueabihf \
-			qemu-system-arm \
-			libsndfile1-dev:armhf \
-			libc6-dev:armhf \
-			make \
-			file && \
-		echo "=== Building ARM unit host ===" && \
-		make -f Makefile.arm && \
-		echo "=== Verifying build ===" && \
-		file unit_host_arm && \
-		ls -lah unit_host_arm'
+		-c 'apt-get update -qq && dpkg --add-architecture armhf && apt-get update -qq && apt-get install -y -qq gcc-arm-linux-gnueabihf qemu-user-static libsndfile1-dev:armhf libc6-dev:armhf make file && echo "=== Building ARM unit host ===" && make -f Makefile.arm && echo "=== Verifying build ===" && file unit_host_arm && ls -lah unit_host_arm'
+	@touch unit_host_arm
 
-# Generate test signals (WAV files)
+podman-build: unit_host_arm
+	@echo "✓ ARM unit host ready"
+
+# Generate test signals (WAV files) - uses container (host lacks numpy/soundfile)
 generate-signals:
-	@echo "Creating test signal directory..."
 	@mkdir -p fixtures
-	@echo "✓ fixtures directory ready for test signals"
+	@if [ ! -f fixtures/sine_440hz.wav ]; then \
+		echo "Generating test signals in Podman container..."; \
+		podman run --rm --entrypoint bash \
+			-v "$(PWD):$(WORKSPACE_DIR):Z" \
+			-w $(WORKSPACE_DIR) \
+			$(CONTAINER_IMAGE) \
+			-c 'apt-get update -qq && apt-get install -y -qq python3 python3-numpy python3-soundfile >/dev/null 2>&1 && python3 generate_signals.py'; \
+	else \
+		echo "✓ Test signals already present"; \
+	fi
 
-# Test specific unit
+# Test a specific unit in QEMU ARM
 test-unit: check-podman podman-build generate-signals
 	@if [ -z "$(UNIT)" ]; then \
 		echo "Usage: make test-unit UNIT=<unit-name>"; \
-		echo "Example: make test-unit UNIT=clouds-revfx"; \
+		echo "Example: make test-unit UNIT=drupiter-synth"; \
 		exit 1; \
 	fi
 	@echo "Testing unit: $(UNIT)"
-	@if [ ! -f "../../drumlogue/$(UNIT)/$(shell echo $(UNIT) | tr '-' '_').drmlgunit" ]; then \
-		echo "Building unit $(UNIT)..."; \
-		cd ../.. && ./build.sh $(UNIT); \
-	fi
-	podman run --rm -it \
-		-v "$(PWD):$(WORKSPACE_DIR):Z" \
-		-v "$(PWD)/../..:/repo:Z" \
-		-w $(WORKSPACE_DIR) \
-		$(CONTAINER_IMAGE) \
-		bash -c '\
-		apt-get update -qq && \
-		apt-get install -y -qq gcc-arm-linux-gnueabihf qemu-system-arm libsndfile1-dev make && \
-		echo "=== Testing $(UNIT) with sine wave ===" && \
-		timeout 300 ./run_qemu.sh \
-			/repo/drumlogue/$(UNIT)/$(shell echo $(UNIT) | tr '-' '_').drmlgunit \
-			test_sine_440.wav \
-			output_$(UNIT)_sine.wav \
-			--param-0 50 --param-1 75 --verbose && \
-		echo "=== Testing $(UNIT) with impulse ===" && \
-		timeout 300 ./run_qemu.sh \
-			/repo/drumlogue/$(UNIT)/$(shell echo $(UNIT) | tr '-' '_').drmlgunit \
-			test_impulse.wav \
-			output_$(UNIT)_impulse.wav \
-			--param-0 80 --param-1 60 --verbose && \
-		echo "=== Analysis ===" && \
-		python3 -c "\
-import soundfile as sf; \
-import numpy as np; \
-import os; \
-for test_type in ['sine', 'impulse']: \
-	filename = f'output_$(UNIT)_{test_type}.wav'; \
-	if os.path.exists(filename): \
-		data, sr = sf.read(filename); \
-		duration = len(data) / sr; \
-		max_level = np.max(np.abs(data)); \
-		rms_level = np.sqrt(np.mean(data**2)); \
-		print(f'✓ {filename}: {duration:.2f}s, max={max_level:.3f}, rms={rms_level:.3f}'); \
-		if max_level < 0.001: \
-			print(f'  ⚠ Very quiet output'); \
-		elif max_level > 0.1: \
-			print(f'  ✓ Good signal level'); \
-	else: \
-		print(f'❌ {filename} not found')"
+	./test-unit.sh $(UNIT)
 
-# Run comprehensive test suite
+# PERF_MON build + CPU profiling in QEMU ARM (before/after comparison workflow)
+perf-test: check-podman podman-build generate-signals
+	@if [ -z "$(UNIT)" ]; then \
+		echo "Usage: make perf-test UNIT=<unit-name>"; \
+		echo "Example: make perf-test UNIT=drupiter-synth"; \
+		exit 1; \
+	fi
+	@echo "Profiling unit: $(UNIT) (rebuilds with PERF_MON=1 __QEMU_ARM__=1)"
+	./test-unit.sh $(UNIT) --profile --perf-mon
+
+# Run comprehensive QEMU ARM test suite over all built units
 podman-test: check-podman podman-build generate-signals
 	@echo "Running comprehensive QEMU ARM test suite..."
-	podman run --rm -it \
-		-v "$(PWD):$(WORKSPACE_DIR):Z" \
-		-v "$(PWD)/../..:/repo:Z" \
-		-w $(WORKSPACE_DIR) \
-		$(CONTAINER_IMAGE) \
-		bash -c '\
-		apt-get update -qq && \
-		apt-get install -y -qq \
-			gcc-arm-linux-gnueabihf \
-			qemu-system-arm \
-			libsndfile1-dev \
-			make \
-			python3 \
-			python3-numpy \
-			python3-soundfile \
-			bc && \
-		echo "=== Available units ===" && \
-		ls /repo/drumlogue/*/config.mk | while read f; do \
-			unit=$$(basename $$(dirname $$f)); \
-			if [ -f "/repo/drumlogue/$$unit/$${unit//-/_}.drmlgunit" ]; then \
-				echo "✓ $$unit"; \
-			else \
-				echo "- $$unit (not built)"; \
-			fi; \
-		done && \
-		echo "" && \
-		echo "=== Testing available units ===" && \
-		for unit in clouds-revfx elementish-synth; do \
-			unit_file="/repo/drumlogue/$$unit/$${unit//-/_}.drmlgunit"; \
-			if [ -f "$$unit_file" ]; then \
-				echo "Testing $$unit..."; \
-				timeout 180 ./run_qemu.sh "$$unit_file" test_sine_440.wav "output_$${unit}_test.wav" --param-0 50 >/dev/null 2>&1 && \
-					echo "✓ $$unit: PASS" || echo "❌ $$unit: FAIL"; \
-			fi; \
-		done'
+	@for unit in $$(ls -1 ../../drumlogue | grep -v common); do \
+		unit_file="../../drumlogue/$$unit/$${unit//-/_}.drmlgunit"; \
+		if [ -f "$$unit_file" ]; then \
+			echo "=== Testing $$unit ==="; \
+			./test-unit.sh $$unit --profile || echo "❌ $$unit: FAIL"; \
+		else \
+			echo "- $$unit (not built, skipping)"; \
+		fi; \
+	done
 
 # Enter container shell for debugging
 podman-shell: check-podman
 	@echo "Entering Podman container shell..."
 	@echo "Available commands:"
-	@echo "  make -f Makefile.linux  # Build ARM unit host"
-	@echo "  ./run_qemu.sh <unit> <in> <out>  # Test unit"
+	@echo "  make -f Makefile.arm  # Build ARM unit host"
+	@echo "  ./test-unit.sh <unit> --profile  # Test unit in QEMU ARM"
 	@echo "  exit  # Return to macOS"
 	@echo ""
 	podman run --rm -it \
@@ -199,7 +148,7 @@ podman-shell: check-podman
 		apt-get update -qq && \
 		apt-get install -y -qq \
 			gcc-arm-linux-gnueabihf \
-			qemu-system-arm \
+			qemu-user-static \
 			libsndfile1-dev \
 			make \
 			file \
@@ -210,35 +159,21 @@ podman-shell: check-podman
 		echo "ARM development environment ready" && \
 		bash'
 
-# Performance comparison
+# Performance comparison (QEMU ARM only; unit must be built)
 performance-test: check-podman podman-build generate-signals
-	@echo "Running performance comparison..."
-	@# Test desktop performance
-	@if [ -d "../clouds-revfx" ]; then \
-		echo "Testing desktop performance..."; \
-		cd ../clouds-revfx && make -s >/dev/null 2>&1 && \
-		time ./clouds_revfx_test ../qemu-arm/test_sine_440.wav ../qemu-arm/desktop_output.wav 2>/dev/null || true; \
+	@if [ -z "$(UNIT)" ]; then \
+		echo "Usage: make performance-test UNIT=<unit-name>"; \
+		echo "Example: make performance-test UNIT=drupiter-synth"; \
+		exit 1; \
 	fi
-	@# Test QEMU ARM performance
-	@echo "Testing QEMU ARM performance..."
-	@podman run --rm -it \
-		-v "$(PWD):$(WORKSPACE_DIR):Z" \
-		-v "$(PWD)/../..:/repo:Z" \
-		-w $(WORKSPACE_DIR) \
-		$(CONTAINER_IMAGE) \
-		bash -c '\
-		apt-get update -qq && apt-get install -y -qq gcc-arm-linux-gnueabihf qemu-system-arm libsndfile1-dev make time && \
-		unit_file="/repo/drumlogue/clouds-revfx/clouds_revfx.drmlgunit"; \
-		if [ -f "$$unit_file" ]; then \
-			echo "QEMU ARM performance:"; \
-			time timeout 180 ./run_qemu.sh "$$unit_file" test_sine_440.wav qemu_output.wav --param-0 50 >/dev/null 2>&1 || echo "Timeout/error"; \
-		fi'
+	@echo "QEMU ARM performance test for: $(UNIT)"
+	./test-unit.sh $(UNIT) --profile
 
 # Clean up generated files
 clean:
-	rm -f unit_host_arm run_qemu.sh
+	rm -f unit_host_arm
 	rm -f test_*.wav output_*.wav desktop_output.wav qemu_output.wav
-	rm -rf build
+	rm -rf build fixtures
 
 # Show container status
 status:

--- a/test/qemu-arm/sdk_stubs.h
+++ b/test/qemu-arm/sdk_stubs.h
@@ -101,8 +101,8 @@ typedef struct unit_param {
     uint8_t frac : 4;       // fractional bits / decimals according to frac_mode
     uint8_t frac_mode : 1;  // 0: fixed point, 1: decimal
     uint8_t reserved : 3;
-    char name[14];          // UNIT_PARAM_NAME_LEN (13) + 1 for null = 14
-} unit_param_t;  // 24 bytes
+    char name[13];          // UNIT_PARAM_NAME_LEN is 12, +1 for null = 13 (verified against runtime.h)
+} unit_param_t;  // 23 bytes
 #pragma pack(pop)
 
 // Unit header (matches logue SDK - must match EXACTLY including packing and types)

--- a/test/qemu-arm/test-unit.sh
+++ b/test/qemu-arm/test-unit.sh
@@ -4,6 +4,8 @@ set -e
 # Simple test script for drumlogue units in QEMU ARM emulation
 # Usage: ./test-unit.sh <unit-name> [--profile] [--perf-mon]
 # Example: ./test-unit.sh clouds-revfx --profile --perf-mon
+# Extra args can be passed to the unit host via EXTRA_ARGS (space separated):
+#   EXTRA_ARGS="--hold-notes --no-rand-params" ./test-unit.sh drupiter-synth --profile
 
 UNIT_NAME="$1"
 PROFILE_FLAG=""
@@ -58,8 +60,21 @@ elif [ ! -f "$UNIT_FILE" ]; then
     exit 1
 fi
 
-# Check if ARM host exists
+# Check if ARM host exists and is up to date (source files newer than binary)
+HOST_SOURCES="unit_host.c wav_file.c sdk_stubs.c unit_host.h wav_file.h sdk_stubs.h Makefile.arm"
+HOST_STALE=0
 if [ ! -f "unit_host_arm" ]; then
+    HOST_STALE=1
+else
+    for src in $HOST_SOURCES; do
+        if [ "$src" -nt "unit_host_arm" ]; then
+            HOST_STALE=1
+            break
+        fi
+    done
+fi
+
+if [ "$HOST_STALE" -eq 1 ]; then
     echo "⚙️  Building ARM unit host..."
     # Use appropriate Makefile based on OS
     if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -74,7 +89,16 @@ fi
 # Check if test signals exist (skip if only testing presets)
 if [ -z "$TEST_PRESETS_FLAG" ] && [ ! -f "$INPUT_WAV" ]; then
     echo "⚙️  Generating test signals..."
-    python3 generate_signals.py
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        # macOS: generate inside container (host may lack numpy/soundfile)
+        podman run --rm --entrypoint bash \
+            -v "$(pwd):/workspace:Z" \
+            -w /workspace \
+            ubuntu:22.04 \
+            -c 'apt-get update -qq && apt-get install -y -qq python3 python3-numpy python3-soundfile >/dev/null 2>&1 && python3 generate_signals.py'
+    else
+        python3 generate_signals.py
+    fi
 fi
 
 # Create output directory
@@ -90,7 +114,8 @@ echo ""
 # Run test - different approach for macOS (podman) vs Linux (native)
 if [[ "$(uname -s)" == "Darwin" ]]; then
     # macOS: Use Podman container with qemu-user-static
-    podman run --rm -it \
+    # Note: -i (not -it) so this works from make and CI without a TTY
+    podman run --rm -i \
         -v "$(pwd):/workspace:Z" \
         -v "$(pwd)/../..:/repo:ro,Z" \
         -w /workspace \
@@ -105,7 +130,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
             /repo/drumlogue/${UNIT_NAME}/${UNIT_FILE_NAME}.drmlgunit \
             /workspace/${INPUT_WAV} \
             /workspace/${OUTPUT_WAV} \
-            --verbose $PROFILE_FLAG $PERF_MON_FLAG
+            --verbose $PROFILE_FLAG $PERF_MON_FLAG $EXTRA_ARGS
     "
 else
     # Linux: Use native qemu-arm directly
@@ -114,7 +139,7 @@ else
         ../../drumlogue/${UNIT_NAME}/${UNIT_FILE_NAME}.drmlgunit \
         ./${INPUT_WAV} \
         ./${OUTPUT_WAV} \
-        --verbose $PROFILE_FLAG $PERF_MON_FLAG
+        --verbose $PROFILE_FLAG $PERF_MON_FLAG $EXTRA_ARGS
 fi
 
 if [ $? -eq 0 ]; then

--- a/test/qemu-arm/unit_host.c
+++ b/test/qemu-arm/unit_host.c
@@ -277,6 +277,7 @@ int unit_host_process_wav(const char* input_path, const char* output_path,
         state->profile_stats.render_count = 0;
         state->profile_stats.total_audio_time = 0.0;
     }
+    state->buffer_size = config->buffer_size;
     
     // For profiling: parameter change tracking for synths
     uint32_t param_change_interval = config->sample_rate;  // Change parameters every 1 second
@@ -321,7 +322,8 @@ int unit_host_process_wav(const char* input_path, const char* output_path,
         
         // For synth units, trigger MIDI notes at intervals
         if (is_synth && total_frames >= next_note_trigger && note_index < num_notes) {
-            if (g_callbacks.unit_note_off && note_triggered) {
+            // Skip note_off when holding notes (e.g., to stress polyphonic mode)
+            if (g_callbacks.unit_note_off && note_triggered && !config->hold_notes) {
                 // Send note off for previous note
                 g_callbacks.unit_note_off(current_note);
             }
@@ -348,7 +350,8 @@ int unit_host_process_wav(const char* input_path, const char* output_path,
         }
         
         // For profiling synths: Change random parameters at intervals
-        if (config->profile && is_synth && total_frames >= next_param_change && 
+        if (config->profile && is_synth && !config->no_rand_params && 
+            total_frames >= next_param_change && 
             param_change_count < max_param_changes) {
             // Change 3-5 random parameters
             uint32_t num_params = state->unit_header->num_params;
@@ -774,13 +777,25 @@ void unit_host_print_perf_mon(unit_host_state_t* state) {
     typedef uint32_t (*get_min_cycles_func)(uint8_t);
     typedef uint32_t (*get_frame_count_func)(uint8_t);
     
-    // Load function pointers (mangled C++ names for dsp::PerfMon static methods)
-    get_counter_count_func get_count = (get_counter_count_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon15GetCounterCountEv");
-    get_counter_name_func get_name = (get_counter_name_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon14GetCounterNameEh");
-    get_average_cycles_func get_avg = (get_average_cycles_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon17GetAverageCyclesEh");
-    get_peak_cycles_func get_peak = (get_peak_cycles_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon14GetPeakCyclesEh");
-    get_min_cycles_func get_min = (get_min_cycles_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon13GetMinCyclesEh");
-    get_frame_count_func get_frames = (get_frame_count_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon13GetFrameCountEh");
+    // Load function pointers.
+    // Preferred: C-linkage export wrappers (perf_mon_get_*) provided by
+    // drumlogue/common/perf_mon.cc when built with PERF_MON=1.
+    // Fallback: mangled C++ names for dsp::PerfMon static methods.
+    get_counter_count_func get_count = (get_counter_count_func)dlsym(state->unit_handle, "perf_mon_get_counter_count");
+    get_counter_name_func get_name = (get_counter_name_func)dlsym(state->unit_handle, "perf_mon_get_counter_name");
+    get_average_cycles_func get_avg = (get_average_cycles_func)dlsym(state->unit_handle, "perf_mon_get_average_cycles");
+    get_peak_cycles_func get_peak = (get_peak_cycles_func)dlsym(state->unit_handle, "perf_mon_get_peak_cycles");
+    get_min_cycles_func get_min = (get_min_cycles_func)dlsym(state->unit_handle, "perf_mon_get_min_cycles");
+    get_frame_count_func get_frames = (get_frame_count_func)dlsym(state->unit_handle, "perf_mon_get_frame_count");
+
+    if (!get_count) {
+        get_count = (get_counter_count_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon15GetCounterCountEv");
+        get_name = (get_counter_name_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon14GetCounterNameEh");
+        get_avg = (get_average_cycles_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon17GetAverageCyclesEh");
+        get_peak = (get_peak_cycles_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon14GetPeakCyclesEh");
+        get_min = (get_min_cycles_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon13GetMinCyclesEh");
+        get_frames = (get_frame_count_func)dlsym(state->unit_handle, "_ZN3dsp7PerfMon13GetFrameCountEh");
+    }
     
     // Check if PERF_MON symbols exist
     if (!get_count || !get_name || !get_avg || !get_peak || !get_min || !get_frames) {
@@ -816,7 +831,16 @@ void unit_host_print_perf_mon(unit_host_state_t* state) {
     printf("%-16s %12s %12s %12s %10s %12s\n", 
            "────────────────", "──────────", "──────────", "──────────", "────────", "───────────");
     
+    // Per-sample counters (DCO/VCF) are measured once per sample frame, while
+    // per-buffer counters (Effects/RenderTotal) are measured once per render
+    // call (possibly once per internal chunk when the unit chunks large
+    // callbacks). Normalize each against the appropriate budget.
+    const uint32_t render_count = state->profile_stats.render_count;
+    const uint32_t buffer_frames = (state->buffer_size > 0) ? state->buffer_size : 256;
+    double cycles_per_buffer = CYCLES_PER_SAMPLE * buffer_frames;
+    
     uint32_t total_avg_cycles = 0;
+    bool all_per_sample = true;
     
     for (uint8_t i = 0; i < counter_count; i++) {
         const char* name = get_name(i);
@@ -827,7 +851,21 @@ void unit_host_print_perf_mon(unit_host_state_t* state) {
         
         if (frames == 0) continue;  // Skip unused counters
         
-        double percent_of_budget = (avg_cycles / CYCLES_PER_SAMPLE) * 100.0;
+        // Per-buffer counters are measured once per render call (or once per
+        // internal chunk when the unit chunks large callbacks). Per-sample
+        // counters are measured once per sample frame, i.e. ~buffer_size per
+        // render call or more. Discriminate by the measurement/render ratio.
+        bool per_buffer = false;
+        double budget = CYCLES_PER_SAMPLE;
+        if (render_count > 0) {
+            double ratio = (double)frames / render_count;
+            if (ratio >= 1.0 && ratio <= 64.0) {
+                per_buffer = true;
+                all_per_sample = false;
+                budget = cycles_per_buffer / ratio;
+            }
+        }
+        double percent_of_budget = (avg_cycles / budget) * 100.0;
         
         printf("%-16s %12u %12u %12u %10u %11.2f%%\n",
                name ? name : "<unnamed>",
@@ -843,25 +881,34 @@ void unit_host_print_perf_mon(unit_host_state_t* state) {
     printf("%-16s %12s %12s %12s %10s %12s\n", 
            "────────────────", "──────────", "──────────", "──────────", "────────", "───────────");
     
-    double total_percent = (total_avg_cycles / CYCLES_PER_SAMPLE) * 100.0;
-    printf("%-16s %12u %12s %12s %10s %11.2f%%", 
-           "TOTAL", total_avg_cycles, "─", "─", "─", total_percent);
+    printf("%-16s %12u %12s %12s %10s", 
+           "TOTAL", total_avg_cycles, "─", "─", "─");
     
-    // Assessment
-    if (total_percent < 50.0) {
-        printf(" ✅ Excellent\n");
-    } else if (total_percent < 80.0) {
-        printf(" ⚠️  Good\n");
-    } else if (total_percent < 100.0) {
-        printf(" ⚠️  Heavy\n");
+    if (all_per_sample) {
+        double total_percent = (total_avg_cycles / CYCLES_PER_SAMPLE) * 100.0;
+        printf(" %11.2f%%", total_percent);
+        
+        // Assessment
+        if (total_percent < 50.0) {
+            printf(" ✅ Excellent\n");
+        } else if (total_percent < 80.0) {
+            printf(" ⚠️  Good\n");
+        } else if (total_percent < 100.0) {
+            printf(" ⚠️  Heavy\n");
+        } else {
+            printf(" ❌ OVERLOAD\n");
+        }
     } else {
-        printf(" ❌ OVERLOAD\n");
+        // Mixed per-sample and per-buffer counters: % is not meaningful
+        printf(" %11s\n", "(mixed)");
     }
     
     printf("\n");
     printf("Notes:\n");
-    printf("  • Cycle counts are measured using ARM cycle counters\n");
-    printf("  • %% of budget assumes %.0f cycles available per sample\n", CYCLES_PER_SAMPLE);
+    printf("  • Per-sample counters (DCO, VCF) are %% of one sample budget (%.0f cycles)\n", CYCLES_PER_SAMPLE);
+    printf("  • Per-buffer counters (Effects, RenderTotal) are %% of one %u-frame buffer budget (%.0f cycles)\n",
+           buffer_frames, cycles_per_buffer);
+    printf("  • Use the host CPU profiling report above for the overall real-time assessment\n");
     printf("  • Actual performance depends on CPU frequency and load\n");
     printf("\n");
     printf("═══════════════════════════════════════════════════════════════\n");
@@ -945,6 +992,8 @@ int unit_host_parse_args(int argc, char* argv[], unit_host_config_t* config) {
         fprintf(stderr, "  --channels <1|2>        Output channels (default: 2)\n");
         fprintf(stderr, "  --test-presets          Test preset loading/switching\n");
         fprintf(stderr, "  --profile               Enable CPU profiling\n");
+        fprintf(stderr, "  --hold-notes            Keep notes held (no note_off between triggers)\n");
+        fprintf(stderr, "  --no-rand-params        Disable random parameter variations during profiling\n");
         fprintf(stderr, "  --verbose               Verbose output\n");
         return UNIT_HOST_ERR_ARGS;
     }
@@ -985,6 +1034,10 @@ int unit_host_parse_args(int argc, char* argv[], unit_host_config_t* config) {
             config->profile = true;
         } else if (strcmp(argv[i], "--perf-mon") == 0) {
             config->perf_mon = true;
+        } else if (strcmp(argv[i], "--hold-notes") == 0) {
+            config->hold_notes = true;
+        } else if (strcmp(argv[i], "--no-rand-params") == 0) {
+            config->no_rand_params = true;
         } else if (strcmp(argv[i], "--verbose") == 0) {
             config->verbose = true;
         }

--- a/test/qemu-arm/unit_host.h
+++ b/test/qemu-arm/unit_host.h
@@ -46,6 +46,8 @@ typedef struct {
     bool profile;               // Enable CPU profiling
     bool perf_mon;              // Enable PERF_MON output (requires unit built with PERF_MON=1)
     bool test_presets;          // Test preset loading/switching
+    bool hold_notes;            // Keep notes held (no note_off between triggers)
+    bool no_rand_params;        // Disable random parameter variations during profiling
 } unit_host_config_t;
 
 /**
@@ -58,6 +60,7 @@ typedef struct {
     uint32_t param_values[24];  // Current parameter values
     bool unit_initialized;      // Unit initialization state
     unit_profiling_stats_t profile_stats; // CPU profiling statistics
+    uint32_t buffer_size;       // Buffer size in frames used for processing
 } unit_host_state_t;
 
 /**


### PR DESCRIPTION
## Summary

Fixes the drupiter synth hang, several functional bugs, the MOD HUB multi-select flakiness, and the QEMU ARM test infrastructure.

### Drupiter — hang & CPU
- The previously checked-in `.drmlgunit` was a `PERF_MON` build containing `PerfMon`/`chrono` symbols. On hardware, `perf_mon.h` reads the DWT register `0xE0001004` which is not valid on this target → crash/hang. Rebuilt a clean production artifact (stripped, 61 KB, no PERF_MON markers).
- Polyphonic VCF coefficient recomputes throttled from ~every sample to 1 Hz steps (matches the mono path), with resonance/mode setters cached per render instead of per voice per sample. QEMU before/after (4-voice poly): RenderTotal peak −15%, avg −3.3%.

### Drupiter — functional bugs
- **Unison DCO2 pitch bend** multiplied frequency by raw semitones (killed DCO2 at center bend, wrong ratios otherwise) → now uses `semitones_to_ratio`.
- **Poly VCA velocity gain** divided the already-normalized velocity by 127 again (velocity had no audible effect) → `0.2 + velocity * 0.8`.
- **SYNC parameter was dead** → hard sync wired into the mono renderer (DCO2 master resets DCO1 phase on wrap).
- **`Render()` truncated callbacks > 64 frames** → now processes in chunks (QEMU output was 75% silence before).
- **Mode switching during notes** was unguarded in `PrepareRenderSetup` → now deferred until voices release.

### MOD HUB (multi-select)
- Preset load clobbered the selected destination's value (`SetParameter(MOD_AMT, 0)` ran after hub restore, so e.g. Init preset loaded LP12 instead of stored LP24) → hub state restored after the parameter loop.
- Shared knob-catch state re-based on destination switch; `hub_values[]` now stores the effective (post-catch) value.
- New `TestHubMultiSelect` regression test in `test/drupiter-synth/main.cc`.

### QEMU ARM test infrastructure
- Makefiles (`test/qemu-arm/`) now drive `test-unit.sh` correctly (`make test-unit` / `make perf-test UNIT=<unit>`); removed broken `run_qemu.sh` references.
- PERF_MON counters readable from the unit host: `override STRIP := true` for PERF_MON builds + C-linkage export wrappers in `perf_mon.cc`.
- Fixed `% of budget` normalization for per-buffer and chunked counters (RenderTotal now reconciles with the host profile, e.g. 45.6% vs 45.7% CPU).
- New host flags: `--hold-notes`, `--no-rand-params` (deterministic polyphonic stress runs); `EXTRA_ARGS` passthrough in `test-unit.sh`.
- Fixed `unit_param_t` struct size mismatch (`name[13]` vs `name[14]`) that scrambled the parameter list display.

## Verification
- Desktop suite: all tests pass (pre-existing Phase 2 analysis warnings unchanged).
- QEMU ARM: unit loads, processes, and profiles correctly; poly A/B comparison run before/after.
- Production artifact: no undefined symbols, no PERF_MON/chrono markers.